### PR TITLE
Added tests for [c *] and [s ep]

### DIFF
--- a/src/retrotype/retrotype_lib.py
+++ b/src/retrotype/retrotype_lib.py
@@ -165,6 +165,7 @@ class TextListing:
             num = 0
 
             for item in code_split:
+                print(line, item)
                 if item.upper() in AHOY_TO_PETCAT:
                     new_codes.append(AHOY_TO_PETCAT[item.upper()])
 

--- a/tests/retrotype_lib_test.py
+++ b/tests/retrotype_lib_test.py
@@ -253,6 +253,18 @@ def test_check_for_loose_braces(lines_list, brace_error_line_num):
         ),
         (['20 print"[4 "*"][5 "4"][BR]"'], ['20 print"****44444{brn}"']),
         (["20 data1, 2, 3, 4"], ["20 data1, 2, 3, 4"]),
+        (
+            ['12 print"[2 " "][cyan][2 "[c *]"] [s ep]"'],
+            ['12 print"  {cyn}{c *}{c *} {s ep}"'],
+        ),
+        (
+            ['12 print"[2 " "][cyan][c *]"'],
+            ['12 print"  {cyn}{c *}"'],
+        ),
+        (
+            ['12 print"{2 " "}{cyan}{c *}"'],
+            ['12 print"  {cyn}{c *}"'],
+        ),
     ],
 )
 def test_ahoy_lines_list(lines_list, new_lines):


### PR DESCRIPTION
Added tests as representatives of special characters not covered by standard conversion to petcat format.  Addresses issue that wasn't tested and caused issues for yanked v0.0.2.