### PR TITLE
Merge develop branch to main for revision 1.1.0 release. (#40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ consult the help for the latest usage:
 **Note:** Currently the only implemented options are for Ahoy C64 programs.
 
 ```
-retrotype_cli [-l load_address] [-s source_format] input_file
+retrotype_cli [-l load_address] [-s source_format] [-w] input_file
 ```
 
 ```
@@ -53,6 +53,8 @@ optional arguments:
                         ahoy1 - Ahoy magazine (Apr-May 1984)
                         ahoy2 - Ahoy magazine (Jun 1984-Apr 1987) (default)
                         ahoy3 - Ahoy magazine (May 1987-)
+
+  -w, --wip             Work in progress, do not output executable binary file.
 ```
 
 As an example for an Ahoy! magazine file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "retrotype"
-version = "1.0.0"
+version = "1.1.0"
 description = "Debuging and conversion tool for 1980s magazine type-in programs"
 readme = "README.md"
 authors = [{ name = "Michael Buhidar", email = "mbuhidar@gmail.com" }]

--- a/src/retrotype/retrotype_cli.py
+++ b/src/retrotype/retrotype_cli.py
@@ -104,6 +104,13 @@ def parse_args(argv):
     )
 
     parser.add_argument(
+        "-w",
+        "--wip",
+        action="store_true",
+        help="Work in progress, do not output executable binary file.\n",
+    )
+
+    parser.add_argument(
         "file_in",
         type=str,
         metavar="input_file",
@@ -219,8 +226,9 @@ def command_line_runner(argv=None, width=None):
 
     ofiles = OutputFiles(bytes_out, ahoy_checksums)
 
-    # Write binary file compatible with Commodore computers or emulators
-    ofiles.write_binary(f"{file_stem}.prg")
+    # Write binary file Commodore computers or emulators if not WIP
+    if not args.wip:
+        ofiles.write_binary(f"{file_stem}.prg")
 
     # Write text file containing line numbers, checksums, and line count
     ofiles.write_checksums(f"{file_stem}.chk")

--- a/tests/retrotype_cli_test.py
+++ b/tests/retrotype_cli_test.py
@@ -14,12 +14,23 @@ from retrotype.retrotype_cli import (
 @pytest.mark.parametrize(
     "argv, arg_valid",
     [
-        (["infile.ahoy"], ["0x0801", "ahoy2", "infile.ahoy"]),
-        (["infile.ahoy", "-s", "ahoy1"], ["0x0801", "ahoy1", "infile.ahoy"]),
-        (["infile.ahoy", "-l", "0x1001"], ["0x1001", "ahoy2", "infile.ahoy"]),
+        (["infile.ahoy"], ["0x0801", "ahoy2", False, "infile.ahoy"]),
+        (
+            ["infile.ahoy", "-s", "ahoy1"],
+            ["0x0801", "ahoy1", False, "infile.ahoy"],
+        ),
+        (
+            ["infile.ahoy", "-l", "0x1001"],
+            ["0x1001", "ahoy2", False, "infile.ahoy"],
+        ),
+        (["infile.ahoy", "-w"], ["0x0801", "ahoy2", True, "infile.ahoy"]),
+        (
+            ["infile.ahoy", "-s", "ahoy3", "-l", "0x1001", "-w"],
+            ["0x1001", "ahoy3", True, "infile.ahoy"],
+        ),
         (
             ["-s", "ahoy3", "infile.ahoy", "-l", "0x1001"],
-            ["0x1001", "ahoy3", "infile.ahoy"],
+            ["0x1001", "ahoy3", False, "infile.ahoy"],
         ),
     ],
 )
@@ -29,7 +40,7 @@ def test_parse_args(argv, arg_valid):
     arguments for a range of different command line input combinations.
     """
     args = parse_args(argv)
-    arg_list = [args.loadaddr[0], args.source[0], args.file_in]
+    arg_list = [args.loadaddr[0], args.source[0], args.wip, args.file_in]
     assert arg_list == arg_valid
 
 
@@ -156,7 +167,8 @@ def test_command_line_runner_nofile(
         (
             "ahoyx",
             '10 PRINT"HELLO"\n20 GOTO10',
-            "usage: __main__.py [-h] [-l load_address] [-s source_format] "
+            "usage: __main__.py [-h] [-l load_address] "
+            "[-s source_format] [-w] "
             "input_file\n"
             "__main__.py: error: argument -s/--source: invalid choice: "
             "'ahoyx'\n"
@@ -166,7 +178,8 @@ def test_command_line_runner_nofile(
         (
             "rand_source_input",
             '10 PRINT"HELLO"\n20 GOTO10',
-            "usage: __main__.py [-h] [-l load_address] [-s source_format] "
+            "usage: __main__.py [-h] [-l load_address] "
+            "[-s source_format] [-w] "
             "input_file\n"
             "__main__.py: error: argument -s/--source: invalid choice: "
             "'rand_source_input'\n"


### PR DESCRIPTION
* Improve return values for check_line_num_seq function.

* Add source reference info containg assembly code for original ahoy debuggers. (#16)

Fixes #15

* Add source reference info containg assembly code for original ahoy debuggers. (#17)

* Add basic type hints. Fixes #2. (#19)

* Fix import issues with char_maps (#20)

* Adjust file permissions in source_reference.

* Fix import issues and move retrotype_cli to src.

* OOP Refactor - fixes #4 (#22)

* Complete TextListing class definition and tests.

* Completed TokenizedLine class definition and tests.

* Completed CheckSums and OutputFiles classes and supporting tests.

* Finish branch for refactor to OOP - prior to pre-commit.

* All files modified via pre-commit.

* Refactor for OOP and apply precommit.

* Improve code coverage and resolve all pre-commit issues.

Update requirements and bump rev for build.

* Move retrotype_cli into retrotype directory.

* Bump rev to 0.0.2 for build.

* Improve return value of check_for_loose_braces(), closes #24. (#26)

* Improve check_line_num_seq() method, closes #21. (#27)

* Bug fix in ahoy_lines_list. (#30)

* Bump rev for release of v0.0.3

* Added tests for [c *] and [s ep] (#34)

* Extract conversion code for xor to checksum within Checksums class. Closes #28. (#35)

* Add test coverage (#36)

* Add check_source to cli

* Add tests to cover cli missing coverage.

* Argparse messaging improvements.

* Add test for line num seq in command_line_runner().

* Add tests for loose braces in command_line_runner().

* Bump rev to 1.0.0 in develop branch for merge to main.

* Add option flag to indicate wip and update README.md for wip flag addition. (#39)

* Bump rev to 1.1.0 in develop branch for merge to main.